### PR TITLE
12 delete /api/comments/:comment_id

### DIFF
--- a/__tests__/comments.test.js
+++ b/__tests__/comments.test.js
@@ -140,8 +140,30 @@ describe("DELETE /api/comments/:comment_id", () =>{
         .expect(204)
         .then(({body}) =>{
             expect(body).toEqual({});
+
+            return db.query(`SELECT * FROM comments`)
+        }).then((comments) =>{
+            expect(comments.rows).toHaveLength(5);
+            const expected = {comment_id : 1}
+            
+            comments.rows.forEach((comment) =>{
+                expect(comment).not.objectContaining(expected);
+            })
         })
     })
+
+    // .delete("/api/treasures/1")
+    //   .expect(204)
+    //   .then(() => {
+    //     return db.query(`SELECT * FROM treasures`);
+    //   })
+    //   .then((treasures) => {
+    //     expect(treasures.rows).toHaveLength(25);
+    //     treasures.rows.forEach((treasure) => {
+    //       const expected = { treasure_id: 1 };
+    //       expect.not.objectContaining(expected);
+    //     });
+    //   });
 
     test("status: 404 when the comment_id doesn't exist", ()=>{
         return request(app)

--- a/__tests__/comments.test.js
+++ b/__tests__/comments.test.js
@@ -132,3 +132,32 @@ describe("POST /api/reviews/:review_id/comments", () =>{
         })
     })
 })
+
+describe("DELETE /api/comments/:comment_id", () =>{
+    test("status: 204 responds with no content upon successfully deleting comment", () =>{
+        return request(app)
+        .delete("/api/comments/1")
+        .expect(204)
+        .then(({body}) =>{
+            expect(body).toEqual({});
+        })
+    })
+
+    test("status: 404 when the comment_id doesn't exist", ()=>{
+        return request(app)
+        .delete("/api/comments/9999")
+        .expect(404)
+        .then(({body}) =>{
+            expect(body.msg).toEqual("Comment id does not exist")
+        })
+    })
+
+    test.only("status: 400 when the passed comment_id is of incorrect type", () =>{
+        return request(app)
+        .delete("/api/comments/eleventy")
+        .expect(400)
+        .then(({body}) =>{
+            expect(body.msg).toEqual("Bad request: invalid data type")
+        })
+    })
+})

--- a/app.js
+++ b/app.js
@@ -17,7 +17,8 @@ const {
 
 const { 
     getCommentsByReviewId,
-    postCommentByReviewId
+    postCommentByReviewId,
+    deleteCommentByCommentId
 } = require("./controllers/comments");
 
 const app = express();
@@ -37,6 +38,7 @@ app.get("/api/users", getUsers);
 //Comments
 app.get("/api/reviews/:review_id/comments", getCommentsByReviewId)
 app.post("/api/reviews/:review_id/comments", postCommentByReviewId)
+app.delete("/api/comments/:comment_id", deleteCommentByCommentId)
 
 //called if route is not found
 app.use("/*", (req, res, next) =>{

--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -1,6 +1,7 @@
 const {
     selectCommentsByReviewId, 
     addCommentByReviewId,
+    removeCommentByCommentId,
 } = require("../models/comments")
 
 exports.getCommentsByReviewId = (req, res, next) =>{
@@ -14,6 +15,14 @@ exports.getCommentsByReviewId = (req, res, next) =>{
 exports.postCommentByReviewId = (req, res, next) =>{
     addCommentByReviewId(req).then((comment) =>{
         res.status(201).send({comment});
+    }).catch((err) =>{
+        next(err);
+    })
+}
+
+exports.deleteCommentByCommentId = (req, res, next) =>{
+    removeCommentByCommentId(req).then(() =>{
+        res.status(204).send();
     }).catch((err) =>{
         next(err);
     })

--- a/models/comments.js
+++ b/models/comments.js
@@ -27,3 +27,15 @@ exports.addCommentByReviewId = (req) =>{
             return comment.rows[0];
         })
 }
+
+exports.removeCommentByCommentId = (req) =>{
+    return db.query(
+        `DELETE FROM comments
+        WHERE comment_id = $1
+        RETURNING *`, [req.params.comment_id]
+    ).then((comments) =>{
+        if(comments.rows.length === 0){
+            return Promise.reject({status: 404, msg : "Comment id does not exist"})
+        }
+    })
+}


### PR DESCRIPTION
Added DELETE /api/comments/:comment_id, adding tests to check the response is correct, handling when the comment_id doesn't exist, and handling when the comment_id data type is invalid.